### PR TITLE
Fixing Deprecated warning

### DIFF
--- a/config/form-templates.php
+++ b/config/form-templates.php
@@ -1,5 +1,5 @@
 <?php
-$config = [
+return [
     'datalistJs' => '<input type="text" id="__{{id}}" name="__{{name}}" list="datalist-{{id}}" autocomplete="off"{{inputAttrs}}>'
         . '<datalist id="datalist-{{id}}"{{datalistAttrs}}>{{content}}</datalist>'
         . '<input type="hidden" name="{{name}}" id="{{id}}">'


### PR DESCRIPTION
CAKE/View/StringTemplate.php:204 
PHP configuration files like "Datalist.form-templates.php" should not set `$config`. Instead return an array. - /Users/challgren/Projects/electric/vendor/cakephp/cakephp/src/View/StringTemplate.php, line: 204 You can disable deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED` in your config/app.php.